### PR TITLE
re-shuffle user list before assignment

### DIFF
--- a/src/clj/avalon/rules/games.clj
+++ b/src/clj/avalon/rules/games.clj
@@ -67,7 +67,7 @@
     (concat special unnamed)))
 
 (defn assign-roles [game]
-  (let [people (.people game)
+  (let [people (shuffle (.people game))
         roles (add-twins (add-lancelot (.roles game)))
         blue (assign-team good :good roles (count people))
         red (assign-team bad :bad roles (count people))]


### PR DESCRIPTION
shaker has a conspiracy theory that people who are added last are more likely to be bad. now we'll shuffle before we assign roles.